### PR TITLE
Remove LRM from text

### DIFF
--- a/src/discord.coffee
+++ b/src/discord.coffee
@@ -101,6 +101,8 @@ class DiscordAdapter extends Adapter
 
     #Use clean content so <@&{id}> looks like @robot-name for replying purposes
     text = message.cleanContent ? message.content
+    #Sometimes there's a left-to-right mark in the cleaned message that needs to be removed
+    text = text.replace /\u200B/, '';
 
     #If in private, pretend the robot name is part of the text for replying purposes
     if (message.channel instanceof Discord.DMChannel)


### PR DESCRIPTION
Remove LRM from cleaned text. 
Sometimes there's a left-to-right mark in the cleaned message that needs to be removed or the message isn't "heard" properly